### PR TITLE
[evol] Duplication des écritures comptables

### DIFF
--- a/.project
+++ b/.project
@@ -3,7 +3,7 @@
 Title=Laurux
 Startup=Start
 Icon=Icones/Larus.png
-Version=3.68.0
+Version=3.69.0
 Component=gb.args
 Component=gb.image
 Component=gb.qt4

--- a/.src/Communs/Fsoc.class
+++ b/.src/Communs/Fsoc.class
@@ -2197,6 +2197,9 @@ Public Sub CREATE()
     "credit Char(10) NOT NULL," &
     "lig Integer(2)," &
     "lind Int NOT NULL AUTO_INCREMENT, " &
+    "libelle VARCHAR(50), " &
+    "numDoc Char(10), " &
+    "numLoc Char(10), " &
     "PRIMARY KEY (lind))" & "ENGINE = MYISAM")
 
   Tab = "Fiches_Tleg"

--- a/.src/Communs/LauruxMaj.module
+++ b/.src/Communs/LauruxMaj.module
@@ -1096,6 +1096,13 @@ Public Sub Verif_Version()
     Try Utils.db.Exec("update Fiches_Parametres set version_pos = &1 ", "3.25")
   Endif
 
+  '************************* Maj 3.69 *********************
+  rResult = Utils.db.Exec("SELECT * from  Fiches_Parametres")
+  If rResult!version = "3.68" Then
+    If Start.LocalSettings["/dbase/Maj"] Then Maj369()
+    Try Utils.db.Exec("update Fiches_Parametres set version = &1 ", "3.69")
+  Endif
+
   If bMaj Then Shell "xdg-open 'http://www.laurux.fr/drupal/changelog'"
 
 End
@@ -5067,6 +5074,17 @@ Public Sub Maj368()
     Endif
   Endif
   
+  If Not Error Then bmaj = True
+
+End
+
+Public Sub Maj369()
+
+  Tab = "Fiches_Ligabon"
+  Try Utils.db.Exec("ALTER TABLE " & Tab & " ADD (libelle VarChar(50))")
+  Try Utils.db.Exec("ALTER TABLE " & Tab & " ADD (numDoc Char(10))")
+  Try Utils.db.Exec("ALTER TABLE " & Tab & " ADD (numLot Char(10))")
+
   If Not Error Then bmaj = True
 
 End

--- a/.src/Compta/Saisecrit.class
+++ b/.src/Compta/Saisecrit.class
@@ -1797,6 +1797,12 @@ Public Sub Button4_Click()
   montantcd = 0
   Totaldb = 0
   Totalcd = 0
+  
+  If ecrA = "1" Then 
+    LignAbt()
+    Return
+  Endif
+  
   With Utils
     LF = 1
     Montant_LostFocus()
@@ -1941,7 +1947,6 @@ Public Sub Button4_Click()
     Endif
   End With
   b = 0
-  If ecrA = "1" Then LignAbt()
 
 End
 
@@ -2982,12 +2987,15 @@ Public Sub LignAbt()
 
   Ecrit1.clear
   If Colabt.Item[3] = "Montant" Then
-    recr = Utils.db.Exec("SELECT * FROM " & Cbase.Table("TabLigabon") & " where numero = &1", Colabt.Current[0])
+    recr = Utils.db.Exec("SELECT * FROM " & Cbase.Table("TabLigabon") & " where numero = &1 order by lig", Colabt.Current[0])
     If recr.Available Then
       Repeat
         Cle = Ecrit1.Count + 1
         numcpt = recr!compte
         Intitulcompte.Text = recr!intitule
+        Libelecrit.Text = recr!libelle
+        numdoc.text = recr!numDoc
+        numlot.text = recr!numLot
         Ecrit1.Add(recr!lig, recr!lig)
         Ecrit1.Item[0] = cle
         Ecrit1.Item[1] = numcpt

--- a/.src/Compta/Tables/Abont.class
+++ b/.src/Compta/Tables/Abont.class
@@ -46,7 +46,8 @@ Public Sub _New()
   Colabt.Columns[1].Text = "Intitulé"
   Colabt.Columns[2].Text = "Type écriture"
   Colabt.Columns[3].Text = "Type saisie"
-  Colecr.Columns.count = 6
+  
+  Colecr.Columns.count = 9
   Colecr.Columns[0].Width = 90
   Colecr.Columns[1].Width = 232
   Colecr.Columns[2].Alignment = 2
@@ -56,11 +57,19 @@ Public Sub _New()
   Colecr.Columns[4].Width = 80
   Colecr.Columns[5].Width = 0
   Colecr.Columns[0].Text = "Compte"
-  Colecr.Columns[1].Text = "Libellé"
+  Colecr.Columns[1].Text = "Intitulé"
   Colecr.Columns[2].Text = "Débit"
   Colecr.Columns[3].Text = "Crédit"
   Colecr.Columns[4].Text = "Lig"
   Colecr.Columns[4].Alignment = 2
+  
+  Colecr.Columns[6].Width = 232
+  Colecr.Columns[6].Text = "Libellé"
+  Colecr.Columns[7].Width = 90
+  Colecr.Columns[7].Text = "Num Doc"
+  Colecr.Columns[8].Width = 90
+  Colecr.Columns[8].Text = "Num Lot"
+  
   Solde.text = "0,00"
   ComboBox1.text = "1- Montant"
   dbl = ""
@@ -182,6 +191,9 @@ Public Sub Colabt_Click()
         If Error Then Colecr.Item[2] = "0,00"
         Colecr.Item[4] = recrt!lig
         Colecr.Item[5] = recrt!lind
+        Colecr.Item[6] = recrt!libelle
+        Colecr.Item[7] = recrt!numDoc
+        Colecr.Item[8] = recrt!numLot
         'ELSE
         'Colecr.Item[2] = Format$(Val(Utils.cpoint(recrt!debit)), "0")
         'Colecr.Item[3] = Format$(Val(Utils.cpoint(recrt!credit)), "0")
@@ -221,6 +233,11 @@ Public Sub Button2_Click()
     Intitule.clear
     Compte.Clear
     Montant.Clear
+    
+    NumDoc.Clear
+    NumLot.Clear
+    LibelleEcrit.Clear
+    
     Solde.text = "0,00"
     Libelle.SetFocus
     Colecr.Clear
@@ -266,6 +283,11 @@ Public Sub Button7_Click()
           Colecr.Item[3] = "0"
         Endif
       Endif
+      
+      Colecr.Item[6] = LibelleEcrit.Text
+      Colecr.Item[7] = NumDoc.Text
+      Colecr.Item[8] = NumLot.Text
+      
       'IF type2 = "VE" AND Debit.value = TRUE THEN Solde.Text = Format$(Val(.cpoint(Solde.Text)) + Val(.cpoint(Montant.Text)), "0.00")
       'IF type2 = "VE" AND Credit.value = TRUE THEN Solde.Text = Format$(Val(.cpoint(Solde.Text)) - Val(.cpoint(Montant.Text)), "0.00")
       If type2 = "AC" And Debit.value = True Then Solde.Text = Format$(Val(.cpoint(Solde.Text)) - Val(.cpoint(Montant.Text)), "0.00")
@@ -281,8 +303,13 @@ Public Sub Button7_Click()
       Endif
       Calculsolde()
       Montant.Text = Format$(Val(Utils.cpoint(Solde.text)), "0.00")
+      
       Compte.Clear
       Intitule.Clear
+      LibelleEcrit.Clear
+      NumDoc.Clear
+      NumLot.Clear
+      
       'Colecr.Clear
       Compte.SetFocus
     End With
@@ -303,6 +330,11 @@ Public Sub Colecr_Activate()
 
   Compte.text = Colecr.Current[0]
   Intitule.Text = Colecr.Current[1]
+  
+  LibelleEcrit.Text = Colecr.Current[6]
+  NumDoc.Text = Colecr.Current[7]
+  NumLot.Text = Colecr.Current[8]
+  
   If Val(Colecr.Current[2]) = 0 Then
     Montant.Text = Colecr.Current[3]
   Else
@@ -351,9 +383,9 @@ Public Sub Button3_Click()
       Repeat
         recrt = Utils.db.Exec("SELECT * FROM " & Cbase.Table("TabLigabon") & " Where lind = &1", Colecr.Item[5])
         If recrt.Available Then
-          Utils.db.Exec("UPdate " & Cbase.Table("TabLigabon") & " set numero = &1, compte = &2, intitule = &3, debit = &4 , credit =&5, lig = &6 Where lind = &7", code.text, Colecr.Item[0], Colecr.Item[1], Colecr.Item[2], Colecr.Item[3], Colecr.Item[4], Colecr.Item[5])
+          Utils.db.Exec("UPdate " & Cbase.Table("TabLigabon") & " set numero = &1, compte = &2, intitule = &3, debit = &4 , credit =&5, lig = &6 , libelle = &8 , numDoc = &9 , numLot = &10 Where lind = &7", code.text, Colecr.Item[0], Colecr.Item[1], Colecr.Item[2], Colecr.Item[3], Colecr.Item[4], Colecr.Item[5], Colecr.Item[6], Colecr.Item[7], Colecr.Item[8])
         Else
-          Utils.db.Exec("INSERT INTO " & Cbase.Table("TabLigabon") & "(numero, compte, intitule, debit, credit, lig) VALUES (&1, &2, &3, &4, &5, &6)", code.text, Colecr.Item[0], Colecr.Item[1], Colecr.Item[2], Colecr.Item[3], Colecr.Item[4])
+          Utils.db.Exec("INSERT INTO " & Cbase.Table("TabLigabon") & "(numero, compte, intitule, debit, credit, lig, libelle, numDoc, numLot) VALUES (&1, &2, &3, &4, &5, &6, &7, &8, &9)", code.text, Colecr.Item[0], Colecr.Item[1], Colecr.Item[2], Colecr.Item[3], Colecr.Item[4], Colecr.Item[6], Colecr.Item[7], Colecr.Item[8])
         Endif
       Until Colecr.MoveNext()
       Colabt.Clear

--- a/.src/Compta/Tables/Abont.form
+++ b/.src/Compta/Tables/Abont.form
@@ -1,11 +1,11 @@
 # Gambas Form File 3.0
 
 { Form Form
-  MoveScaled(0,0,77,92)
+  MoveScaled(0,0,115,85)
   Background = Color.Background
   Text = ("Création des masques de saisies d'écritures.")
   { HBox1 HBox
-    MoveScaled(1,86,75,4)
+    MoveScaled(1,80,75,4)
     Font = Font["Serif,-1"]
     Spacing = True
     { Button1 Button
@@ -50,25 +50,25 @@
     }
   }
   { Frame1 Frame
-    MoveScaled(5,42,67,43)
+    MoveScaled(1,40,112,39)
     Font = Font["Serif,-1"]
     Text = ("Détail écriture")
     { Label5 Label
-      MoveScaled(2,14.25,15,3)
+      MoveScaled(-1,18,15,3)
       Font = Font["Serif,-1"]
       Text = ("Montant")
       Alignment = Align.Center
     }
     { Montant TextBox Cmpt
       Name = "Montant"
-      MoveScaled(3,17,14,3)
+      MoveScaled(11,18,14,3)
       Font = Font["Serif,-1"]
       Background = Color.TextBackground
       Tag = "4"
       MaxLength = 12
     }
     { Panel3 Panel
-      MoveScaled(18,16.125,32,4)
+      MoveScaled(26,18,32,4)
       Font = Font["Serif,-1"]
       Border = Border.Plain
       { Debit RadioButton
@@ -84,83 +84,82 @@
       }
     }
     { Label6 Label
-      MoveScaled(49.625,14.25,15,3)
+      MoveScaled(57,18,15,3)
       Font = Font["Serif,-1"]
       Text = ("Solde écriture")
       Alignment = Align.Center
     }
     { Solde TextBox
-      MoveScaled(51,17,13.625,3)
+      MoveScaled(71,18,13.625,3)
       Font = Font["Serif,-1"]
       Background = Color.TextBackground
       ReadOnly = True
       MaxLength = 8
     }
     { Frame2 Frame
-      MoveScaled(2,3,63,11)
+      MoveScaled(2,3,109,14)
       Font = Font["Serif,-1"]
       { Label3 Label
-        MoveScaled(1,1,15,3)
+        MoveScaled(1,0,15,3)
         Font = Font["Serif,-1"]
         Text = ("N° de compte")
         Alignment = Align.Center
       }
       { compte TextBox Cmpt
         Name = "compte"
-        MoveScaled(1,4,14,3)
+        MoveScaled(1,3,14,3)
         Font = Font["Serif,-1"]
         Background = Color.TextBackground
         Tag = "3"
         MaxLength = 8
       }
       { Button6 Button
-        MoveScaled(15,3.75,3.625,3.625)
+        MoveScaled(15,3,3.625,3.625)
         Font = Font["Serif,-1"]
         ToolTip = ("Cliquer pour recuperer votre compte.")
         Picture = Picture["Icones/next_frame.png"]
       }
       { Label4 Label
-        MoveScaled(20,1,42.375,3)
+        MoveScaled(20,0,42.375,3)
         Font = Font["Serif,-1"]
         Text = ("Intitulé")
         Alignment = Align.Center
       }
       { Intitule TextBox
-        MoveScaled(20,4,42.375,3)
+        MoveScaled(20,3,42.375,3)
         Font = Font["Serif,-1"]
         Background = Color.TextBackground
         ReadOnly = True
         MaxLength = 40
       }
       { Bclient RadioButton
-        MoveScaled(46,7.625,14,3)
-        Visible = False
+        MoveScaled(46,6,14,3)
         Font = Font["Serif,-1"]
         ToolTip = ("Cliquez ici pour activer le type de compte clients")
         Text = Shortcut(("Clients"), "C")
       }
       { Bfournisseur RadioButton
-        MoveScaled(2,7.625,16,3)
+        MoveScaled(2,6,16,3)
         Font = Font["Serif,-1"]
         ToolTip = ("Cliquez ici pour activer le type de compte fournisseurs")
         Text = Shortcut(("Fournisseurs"), "F")
         Value = True
       }
       { Bgestion RadioButton
-        MoveScaled(19,7.625,13,3)
+        MoveScaled(19,6,13,3)
         Font = Font["Serif,-1"]
         ToolTip = ("Cliquez ici pour activer le type de compte gestion")
         Text = Shortcut(("Gestion"), "G")
       }
       { Bbilan RadioButton
-        MoveScaled(34,7.625,12,3)
+        MoveScaled(34,6,12,3)
         Font = Font["Serif,-1"]
         ToolTip = ("Cliquez ici pour activer le type de compte bilan")
         Text = Shortcut(("Bilan"), "B")
       }
     }
     { Button7 Button
-      MoveScaled(43,21,22,4)
+      MoveScaled(89,18,22,4)
       Font = Font["Serif,Bold,-1"]
       Background = Color.ButtonBackground
       ToolTip = ("Enregistrer l'écriture saisie.")
@@ -168,7 +167,7 @@
       Picture = Picture["Icones/filesave.png"]
     }
     { Colecr ColumnView
-      MoveScaled(2,26,63,15)
+      MoveScaled(2,23,109,15)
       Font = Font["Serif,-1"]
       Background = Color.TextBackground
       Sorted = True
@@ -176,7 +175,7 @@
     }
   }
   { Frame4 Frame
-    MoveScaled(5,24,67,17)
+    MoveScaled(1,22,67,17)
     Font = Font["Serif,-1"]
     Text = ("Numéro de masque")
     { Label1 Label
@@ -230,5 +229,41 @@
     Background = Color.TextBackground
     Sorted = True
     AutoResize = False
+  }
+  { LibelleEcrit TextBox
+    MoveScaled(16,53,34,3)
+    Font = Font["Serif,-1"]
+    Background = Color.TextBackground
+    MaxLength = 40
+  }
+  { Label7 Label
+    MoveScaled(7,53,11,3)
+    Font = Font["Serif,-1"]
+    Text = ("Libellé")
+    Alignment = Align.Center
+  }
+  { NumDoc TextBox
+    MoveScaled(59,53,15,3)
+    Font = Font["Serif,-1"]
+    Background = Color.TextBackground
+    MaxLength = 40
+  }
+  { Label8 Label
+    MoveScaled(47,53,15,3)
+    Font = Font["Serif,-1"]
+    Text = ("Num Doc")
+    Alignment = Align.Center
+  }
+  { NumLot TextBox
+    MoveScaled(85,53,24,3)
+    Font = Font["Serif,-1"]
+    Background = Color.TextBackground
+    MaxLength = 40
+  }
+  { Label9 Label
+    MoveScaled(73,53,15,3)
+    Font = Font["Serif,-1"]
+    Text = ("Num Lot")
+    Alignment = Align.Center
   }
 }

--- a/.src/Compta/Tresor.class
+++ b/.src/Compta/Tresor.class
@@ -1403,6 +1403,11 @@ End
 Public Sub ToggleButton4_Click()
 
   Prov = 1
+  If ecrA = "1" Then 
+    LignAbt()
+    Cleanchamps()
+    Return
+  Endif
   Montant_LF()
   If b <> 1 Then
     If numcompte.Text = "" Then
@@ -1487,7 +1492,6 @@ Public Sub ToggleButton4_Click()
     Endif
     b = 0
   Endif
-  If ecrA = "1" Then LignAbt()
   Cleanchamps()
 Catch
   If son Then
@@ -2470,10 +2474,13 @@ Public Sub LignAbt()
   Dim recr As Result
 
   Ecrit1.clear
-  recr = Utils.db.Exec("SELECT * FROM " & Cbase.Table("TabLigabon") & " where numero = &1", Colabt.Current[0], "0,00")
+  recr = Utils.db.Exec("SELECT * FROM " & Cbase.Table("TabLigabon") & " where numero = &1 order by lig", Colabt.Current[0], "0,00")
   If recr.Available Then
     Credit.Value = True
     Repeat
+      Libelecrit.Text = recr!libelle
+      numdoc.text = recr!numDoc
+      numlot.text = recr!numLot
       Ecrit1.Add(recr!lig, recr!lig)
       Ecrit1.Item[0] = recr!compte
       Ecrit1.Item[1] = Libelecrit.Text
@@ -2483,8 +2490,10 @@ Public Sub LignAbt()
       Ecrit1.Item[5] = Format$(Val(Utils.cpoint(recr!credit)), "0.00")
       Ecrit1.Item[4] = Format$(Val(Utils.cpoint(recr!debit)), "0.00")
       Ecrit1.Item[6] = datej.Text
-      Ecrit1.Item[7] = Intitulcompte.Text
+      Ecrit1.Item[7] = recr!intitule
       Ecrit1.Item[8] = journal.Text
+      Ecrit1.Item[9] = datee.Text
+      
       If Val(Utils.CPoint(soldeecrit.Text)) = 0 Then soldeecrit.Text = "0,00"
     Until recr.MoveNext()
   Endif

--- a/Laurux01.sql
+++ b/Laurux01.sql
@@ -2940,6 +2940,9 @@ CREATE TABLE `Fiches_Ligabon` (
   `credit` char(10) NOT NULL,
   `lig` int(2) DEFAULT NULL,
   `lind` int(11) NOT NULL AUTO_INCREMENT,
+  `libelle` varchar(50) DEFAULT NULL,
+  `numDoc` char(10) DEFAULT NULL,
+  `numLot` char(10) DEFAULT NULL,
   PRIMARY KEY (`lind`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
Ajout des champs libelle écriture, num doc et num lot dans l'écran de Masque de saisie.

Permettre de saisir une ecriture normale ou de trésorerie complete à partir d'une masque de saisie. 
Sur l'écran de saisie après l'appel avec F7 de l'écran de masque de saisie, une fois que la masque à été choisi, appuyer sur "Enregistrer" pour que l'ensemble des lignes apparaisse dans le tableau.